### PR TITLE
Fix for mounts with spaces in their names

### DIFF
--- a/addons/ChickenDance/chickendance.lua
+++ b/addons/ChickenDance/chickendance.lua
@@ -111,7 +111,7 @@ ashita.events.register('command', 'command_cb', function(e)
         local mountIndex = possibleMounts[rand];
         local mountName = MountEnum[mountIndex];
         if(mountName ~= nil)then
-            local mountStr = '/mount ' .. mountName;
+            local mountStr = '/mount "' .. mountName .. '"';
             AshitaCore:GetChatManager():QueueCommand(-1, mountStr);
         end
     end


### PR DESCRIPTION
Just noticed this was failing for mounts with spaces in their names (Spectral Chair, Iron Giant etc)
Seems to be fixed by just wrapping the whole thing in quotes